### PR TITLE
devops: disable pypy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,9 @@ jobs:
         python-version: ["3.10", "3.13"]
         runs-on: [ubuntu-latest] #, macos-latest, windows-latest]
 
-        include:
-          - python-version: pypy-3.10
-            runs-on: ubuntu-latest
+        # include:
+        #   - python-version: pypy-3.10
+        #     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This package depends on `adios2` through `xarray-adios2`/`adios2py`, and the former doesn't seem to work right on pypy, and I don't think we really care, so let's just disable this check