### PR TITLE
Change 2nd dimension name to avoid crash for gauss cases

### DIFF
--- a/src/pscpy/psc.py
+++ b/src/pscpy/psc.py
@@ -111,7 +111,7 @@ def decode_psc(
         ds = ds.rename_dims(
             {
                 da.dims[0]: "step",
-                da.dims[1]: "component",
+                # dims[1] is the "component" dimension, which gets removed later
                 da.dims[2]: "z",
                 da.dims[3]: "y",
                 da.dims[4]: "x",
@@ -123,8 +123,8 @@ def decode_psc(
     data_vars = {}
     for var_name in ds:
         if var_name in field_to_component:
-            for field, component in field_to_component[var_name].items():  # type: ignore[index]
-                data_vars[field] = ds[var_name].isel({"component": component})
+            for field, component_idx in field_to_component[var_name].items():  # type: ignore[index]
+                data_vars[field] = ds[var_name][component_idx, :, :, :]
         ds = ds.drop_vars([var_name])
     ds = ds.assign(data_vars)
 

--- a/src/pscpy/psc.py
+++ b/src/pscpy/psc.py
@@ -111,7 +111,7 @@ def decode_psc(
         ds = ds.rename_dims(
             {
                 da.dims[0]: "step",
-                da.dims[1]: f"comp_{da.name}",
+                da.dims[1]: "component",
                 da.dims[2]: "z",
                 da.dims[3]: "y",
                 da.dims[4]: "x",
@@ -124,7 +124,7 @@ def decode_psc(
     for var_name in ds:
         if var_name in field_to_component:
             for field, component in field_to_component[var_name].items():  # type: ignore[index]
-                data_vars[field] = ds[var_name].isel({f"comp_{var_name}": component})
+                data_vars[field] = ds[var_name].isel({"component": component})
         ds = ds.drop_vars([var_name])
     ds = ds.assign(data_vars)
 


### PR DESCRIPTION
Fixes #21 

The name of the 2nd dimension doesn't matter, since it gets dropped. This fixes the case where multiple dataarrays exist in one dataset (e.g. `rho` and `dive` for gauss outputs), where previously, the name of the 2nd dimension shared by *all dataarrays* was set to contain the name of the *first dataarray*.

An alternative approach would have been to change gauss output on the PSC side to produce a single datarray with 2 components, `dive` and `rho`.

It might be nice to have this behavior enforced by tests, but there are no gauss outputs in the sample directory. That could merit a new issue.