### PR TITLE
Add utility functions for recentering data

### DIFF
--- a/src/pscpy/__init__.py
+++ b/src/pscpy/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pathlib
 
 from ._version import version as __version__
-from .postprocessing import recenter
+from .postprocessing import get_recentered
 from .psc import decode_psc
 
 sample_dir = pathlib.Path(__file__).parent / "sample"
@@ -18,6 +18,6 @@ sample_dir = pathlib.Path(__file__).parent / "sample"
 __all__ = [
     "__version__",
     "decode_psc",
-    "recenter",
+    "get_recentered",
     "sample_dir",
 ]

--- a/src/pscpy/__init__.py
+++ b/src/pscpy/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pathlib
 
 from ._version import version as __version__
+from .postprocessing import recenter
 from .psc import decode_psc
 
 sample_dir = pathlib.Path(__file__).parent / "sample"
@@ -17,5 +18,6 @@ sample_dir = pathlib.Path(__file__).parent / "sample"
 __all__ = [
     "__version__",
     "decode_psc",
+    "recenter",
     "sample_dir",
 ]

--- a/src/pscpy/__init__.py
+++ b/src/pscpy/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pathlib
 
 from ._version import version as __version__
-from .postprocessing import get_recentered
+from .postprocessing import auto_recenter, get_recentered
 from .psc import decode_psc
 
 sample_dir = pathlib.Path(__file__).parent / "sample"
@@ -17,6 +17,7 @@ sample_dir = pathlib.Path(__file__).parent / "sample"
 
 __all__ = [
     "__version__",
+    "auto_recenter",
     "decode_psc",
     "get_recentered",
     "sample_dir",

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -45,3 +45,17 @@ def auto_recenter(
 
     Variables are also renamed appropriately. In the example above, `ex_ec` would be renamed to `ex_nc`.
     """
+
+    interp_dir = {"cc": 1, "nc": -1}[to_centering]
+
+    for var_name in ds:
+        if not isinstance(var_name, str):
+            continue
+
+        for dim, boundary_method in boundaries.items():
+            if to_centering == "nc" and var_name.endswith(f"{dim}_ec"):
+                ds[var_name] = get_recentered(ds[var_name], dim, interp_dir, boundary=boundary_method)
+
+        new_name = var_name[:-3] + "_" + to_centering
+        ds[new_name] = ds[var_name].rename(new_name)
+        del ds[var_name]

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -6,6 +6,7 @@ import xarray as xr
 
 type BoundaryInterpMethod = Literal["periodic", "pad", "zero"]
 
+
 def get_recentered(
     da: xr.DataArray,
     dim: str,
@@ -30,3 +31,17 @@ def get_recentered(
         shifted[{dim: boundary_idx}] = 0
 
     return 0.5 * (da + shifted)
+
+
+def auto_recenter(
+    ds: xr.Dataset,
+    to_centering: Literal["nc", "cc"],
+    **boundaries: BoundaryInterpMethod,
+):
+    """
+    Recenters variables with names matching a particular pattern to the given centering.
+
+    In particular, variable name ending in `"{dim}_ec"`, `"{dim}_fc"`, `"_nc"`, or `"_cc"`, where `dim` is a dimension name and a key in `boundaries`, is recentered appropriately. For example, if `to_centering="nc"` (node-centered), a variable ending in "x_ec" (i.e., the x-component of an edge-centered field) will be recentered along x, but not y or z, since it is already node-centered in those dimensions.
+
+    Variables are also renamed appropriately. In the example above, `ex_ec` would be renamed to `ex_nc`.
+    """

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -18,4 +18,14 @@ def recenter(
     For example, `interp_dir=-1` interpolates node-centered values from cell-centered values, because each node center is at a lesser coordinate than the cell center of the same index.
     """
 
-    return da
+    shifted = da.roll({dim: -interp_dir}, roll_coords=False)
+    boundary_idx = {-1: 0, 1: -1}[interp_dir]
+
+    if boundary == "periodic":
+        pass  # this case is already handled by the behavior of roll()
+    elif boundary == "pad":
+        shifted[{dim: boundary_idx}] = da[{dim: boundary_idx}]
+    elif boundary == "zero":
+        shifted[{dim: boundary_idx}] = 0
+
+    return 0.5 * (da + shifted)

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import xarray as xr
 
-type BoundaryInterpMethod = Literal["periodic", "pad", "zero"]
+BoundaryInterpMethod: TypeAlias = Literal["periodic", "pad", "zero"]
 
 
 def get_recentered(
@@ -33,7 +33,7 @@ def get_recentered(
     return 0.5 * (da + shifted)
 
 
-def _rename_var(ds: xr.Dataset, old_name: str, new_name: str):
+def _rename_var(ds: xr.Dataset, old_name: str, new_name: str) -> None:
     ds[new_name] = ds[old_name].rename(new_name)
     del ds[old_name]
 
@@ -42,7 +42,7 @@ def auto_recenter(
     ds: xr.Dataset,
     to_centering: Literal["nc", "cc"],
     **boundaries: BoundaryInterpMethod,
-):
+) -> None:
     """
     Recenters variables with names matching a particular pattern to the given centering.
 
@@ -51,7 +51,7 @@ def auto_recenter(
     Variables are also renamed appropriately. In the example above, `ex_ec` would be renamed to `ex_nc`.
     """
 
-    interp_dir = {"cc": 1, "nc": -1}[to_centering]
+    interp_dir: Literal[-1, 1] = {"cc": 1, "nc": -1}[to_centering]  # type: ignore[assignment]
 
     for var_name in ds:
         if not isinstance(var_name, str):

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -33,6 +33,11 @@ def get_recentered(
     return 0.5 * (da + shifted)
 
 
+def _rename_var(ds: xr.Dataset, old_name: str, new_name: str):
+    ds[new_name] = ds[old_name].rename(new_name)
+    del ds[old_name]
+
+
 def auto_recenter(
     ds: xr.Dataset,
     to_centering: Literal["nc", "cc"],
@@ -65,6 +70,4 @@ def auto_recenter(
                 needs_rename = True
 
         if needs_rename:
-            new_name = var_name[:-3] + "_" + to_centering
-            ds[new_name] = ds[var_name].rename(new_name)
-            del ds[var_name]
+            _rename_var(ds, var_name, var_name[:-3] + "_" + to_centering)

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -55,6 +55,10 @@ def auto_recenter(
         for dim, boundary_method in boundaries.items():
             if to_centering == "nc" and var_name.endswith(f"{dim}_ec"):
                 ds[var_name] = get_recentered(ds[var_name], dim, interp_dir, boundary=boundary_method)
+            elif to_centering == "cc" and var_name.endswith(f"{dim}_ec"):
+                for other_dim, other_boundary_method in boundaries.items():
+                    if other_dim != dim:
+                        ds[var_name] = get_recentered(ds[var_name], other_dim, interp_dir, boundary=other_boundary_method)
 
         new_name = var_name[:-3] + "_" + to_centering
         ds[new_name] = ds[var_name].rename(new_name)

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import xarray as xr
+
+
+def recenter(
+    da: xr.DataArray,
+    dim: str,
+    interp_dir: Literal[-1, 1],
+    *,
+    boundary: Literal["periodic", "pad", "zero"] = "periodic",
+) -> xr.DataArray:
+    """
+    Returns a new array with values along `dim` recentered in the direction `interp_dir`.
+
+    For example, `interp_dir=-1` interpolates node-centered values from cell-centered values, because each node center is at a lesser coordinate than the cell center of the same index.
+    """
+
+    return da

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -60,18 +60,33 @@ def auto_recenter(
         needs_rename = False
 
         for dim, boundary_method in boundaries.items():
-            if to_centering == "nc" and var_name.endswith(f"{dim}_ec") or to_centering == "cc" and var_name.endswith(f"{dim}_fc"):
-                ds[var_name] = get_recentered(ds[var_name], dim, interp_dir, boundary=boundary_method)
+            if (to_centering == "nc" and var_name.endswith(f"{dim}_ec")) or (
+                to_centering == "cc" and var_name.endswith(f"{dim}_fc")
+            ):
+                ds[var_name] = get_recentered(
+                    ds[var_name], dim, interp_dir, boundary=boundary_method
+                )
                 needs_rename = True
-            elif to_centering == "cc" and var_name.endswith(f"{dim}_ec") or to_centering == "nc" and var_name.endswith(f"{dim}_fc"):
+            elif (to_centering == "cc" and var_name.endswith(f"{dim}_ec")) or (
+                to_centering == "nc" and var_name.endswith(f"{dim}_fc")
+            ):
                 for other_dim, other_boundary_method in boundaries.items():
                     if other_dim != dim:
-                        ds[var_name] = get_recentered(ds[var_name], other_dim, interp_dir, boundary=other_boundary_method)
+                        ds[var_name] = get_recentered(
+                            ds[var_name],
+                            other_dim,
+                            interp_dir,
+                            boundary=other_boundary_method,
+                        )
                 needs_rename = True
 
-        if to_centering == "cc" and var_name.endswith("_nc") or to_centering == "nc" and var_name.endswith("_cc"):
+        if (to_centering == "cc" and var_name.endswith("_nc")) or (
+            to_centering == "nc" and var_name.endswith("_cc")
+        ):
             for dim, boundary_method in boundaries.items():
-                ds[var_name] = get_recentered(ds[var_name], dim, interp_dir, boundary=boundary_method)
+                ds[var_name] = get_recentered(
+                    ds[var_name], dim, interp_dir, boundary=boundary_method
+                )
             needs_rename = True
 
         if needs_rename:

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -69,5 +69,10 @@ def auto_recenter(
                         ds[var_name] = get_recentered(ds[var_name], other_dim, interp_dir, boundary=other_boundary_method)
                 needs_rename = True
 
+        if to_centering == "cc" and var_name.endswith("_nc") or to_centering == "nc" and var_name.endswith("_cc"):
+            for dim, boundary_method in boundaries.items():
+                ds[var_name] = get_recentered(ds[var_name], dim, interp_dir, boundary=boundary_method)
+            needs_rename = True
+
         if needs_rename:
             _rename_var(ds, var_name, var_name[:-3] + "_" + to_centering)

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -52,14 +52,19 @@ def auto_recenter(
         if not isinstance(var_name, str):
             continue
 
+        needs_rename = False
+
         for dim, boundary_method in boundaries.items():
             if to_centering == "nc" and var_name.endswith(f"{dim}_ec"):
                 ds[var_name] = get_recentered(ds[var_name], dim, interp_dir, boundary=boundary_method)
+                needs_rename = True
             elif to_centering == "cc" and var_name.endswith(f"{dim}_ec"):
                 for other_dim, other_boundary_method in boundaries.items():
                     if other_dim != dim:
                         ds[var_name] = get_recentered(ds[var_name], other_dim, interp_dir, boundary=other_boundary_method)
+                needs_rename = True
 
-        new_name = var_name[:-3] + "_" + to_centering
-        ds[new_name] = ds[var_name].rename(new_name)
-        del ds[var_name]
+        if needs_rename:
+            new_name = var_name[:-3] + "_" + to_centering
+            ds[new_name] = ds[var_name].rename(new_name)
+            del ds[var_name]

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -60,10 +60,10 @@ def auto_recenter(
         needs_rename = False
 
         for dim, boundary_method in boundaries.items():
-            if to_centering == "nc" and var_name.endswith(f"{dim}_ec"):
+            if to_centering == "nc" and var_name.endswith(f"{dim}_ec") or to_centering == "cc" and var_name.endswith(f"{dim}_fc"):
                 ds[var_name] = get_recentered(ds[var_name], dim, interp_dir, boundary=boundary_method)
                 needs_rename = True
-            elif to_centering == "cc" and var_name.endswith(f"{dim}_ec"):
+            elif to_centering == "cc" and var_name.endswith(f"{dim}_ec") or to_centering == "nc" and var_name.endswith(f"{dim}_fc"):
                 for other_dim, other_boundary_method in boundaries.items():
                     if other_dim != dim:
                         ds[var_name] = get_recentered(ds[var_name], other_dim, interp_dir, boundary=other_boundary_method)

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -5,7 +5,7 @@ from typing import Literal
 import xarray as xr
 
 
-def recenter(
+def get_recentered(
     da: xr.DataArray,
     dim: str,
     interp_dir: Literal[-1, 1],

--- a/src/pscpy/postprocessing.py
+++ b/src/pscpy/postprocessing.py
@@ -4,13 +4,14 @@ from typing import Literal
 
 import xarray as xr
 
+type BoundaryInterpMethod = Literal["periodic", "pad", "zero"]
 
 def get_recentered(
     da: xr.DataArray,
     dim: str,
     interp_dir: Literal[-1, 1],
     *,
-    boundary: Literal["periodic", "pad", "zero"] = "periodic",
+    boundary: BoundaryInterpMethod = "periodic",
 ) -> xr.DataArray:
     """
     Returns a new array with values along `dim` recentered in the direction `interp_dir`.

--- a/src/pscpy/psc.py
+++ b/src/pscpy/psc.py
@@ -32,7 +32,7 @@ class RunInfo:
         self.z = self._get_coord(2)
 
     def _get_coord(self, coord_idx: int) -> NDArray[Any]:
-        return np.linspace(  # type: ignore[no-any-return]
+        return np.linspace(
             start=self.corner[coord_idx],
             stop=self.corner[coord_idx] + self.length[coord_idx],
             num=self.gdims[coord_idx],

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -46,3 +46,18 @@ def test_recenter_zero_right(test_dataarray):
     recentered = pscpy.get_recentered(test_dataarray, "x", 1, boundary="zero")
     assert np.array_equal(recentered.coords, test_dataarray.coords)
     assert np.array_equal(recentered, [4.5, 5.5, 5.5, 2.5])
+
+
+@pytest.fixture
+def test_dataset_ec():
+    coords = [[0, 1], [0, 1, 2]]
+    dims = ["x", "y"]
+    ex_ec = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
+    ey_ec = xr.DataArray([[0, 2, 4], [1, 3, 5]], coords, dims)
+    return xr.Dataset({"ex_ec": ex_ec, "ey_ec": ey_ec})
+
+
+def test_autorecenter_ec_to_nc(test_dataset_ec):
+    pscpy.auto_recenter(test_dataset_ec, "nc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_ec.ex_nc, [[0, 1, 2], [1.5, 2.5, 3.5]])
+    assert np.array_equal(test_dataset_ec.ey_nc, [[0, 1, 3], [1, 2, 4]])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -54,16 +54,19 @@ def test_dataset_ec():
     dims = ["x", "y"]
     ex_ec = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
     ey_ec = xr.DataArray([[0, 2, 4], [1, 3, 5]], coords, dims)
-    return xr.Dataset({"ex_ec": ex_ec, "ey_ec": ey_ec})
+    dont_touch = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
+    return xr.Dataset({"ex_ec": ex_ec, "ey_ec": ey_ec, "dont_touch": dont_touch})
 
 
 def test_autorecenter_ec_to_nc(test_dataset_ec):
     pscpy.auto_recenter(test_dataset_ec, "nc", x="pad", y="pad")
     assert np.array_equal(test_dataset_ec.ex_nc, [[0, 1, 2], [1.5, 2.5, 3.5]])
     assert np.array_equal(test_dataset_ec.ey_nc, [[0, 1, 3], [1, 2, 4]])
+    assert np.array_equal(test_dataset_ec.dont_touch, [[0, 1, 2], [3, 4, 5]])
 
 
 def test_autorecenter_ec_to_cc(test_dataset_ec):
     pscpy.auto_recenter(test_dataset_ec, "cc", x="pad", y="pad")
     assert np.array_equal(test_dataset_ec.ex_cc, [[0.5, 1.5, 2], [3.5, 4.5, 5]])
     assert np.array_equal(test_dataset_ec.ey_cc, [[0.5, 2.5, 4.5], [1, 3, 5]])
+    assert np.array_equal(test_dataset_ec.dont_touch, [[0, 1, 2], [3, 4, 5]])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -70,3 +70,27 @@ def test_autorecenter_ec_to_cc(test_dataset_ec):
     assert np.array_equal(test_dataset_ec.ex_cc, [[0.5, 1.5, 2], [3.5, 4.5, 5]])
     assert np.array_equal(test_dataset_ec.ey_cc, [[0.5, 2.5, 4.5], [1, 3, 5]])
     assert np.array_equal(test_dataset_ec.dont_touch, [[0, 1, 2], [3, 4, 5]])
+
+
+@pytest.fixture
+def test_dataset_fc():
+    coords = [[0, 1], [0, 1, 2]]
+    dims = ["x", "y"]
+    hx_fc = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
+    hy_fc = xr.DataArray([[0, 2, 4], [1, 3, 5]], coords, dims)
+    dont_touch = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
+    return xr.Dataset({"hx_fc": hx_fc, "hy_fc": hy_fc, "dont_touch": dont_touch})
+
+
+def test_autorecenter_fc_to_nc(test_dataset_fc):
+    pscpy.auto_recenter(test_dataset_fc, "nc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_fc.hx_nc, [[0, 0.5, 1.5], [3, 3.5, 4.5]])
+    assert np.array_equal(test_dataset_fc.hy_nc, [[0, 2, 4], [0.5, 2.5, 4.5]])
+    assert np.array_equal(test_dataset_fc.dont_touch, [[0, 1, 2], [3, 4, 5]])
+
+
+def test_autorecenter_fc_to_cc(test_dataset_fc):
+    pscpy.auto_recenter(test_dataset_fc, "cc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_fc.hx_cc, [[1.5, 2.5, 3.5], [3, 4, 5]])
+    assert np.array_equal(test_dataset_fc.hy_cc, [[1, 3, 4], [2, 4, 5]])
+    assert np.array_equal(test_dataset_fc.dont_touch, [[0, 1, 2], [3, 4, 5]])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -54,22 +54,19 @@ def test_dataset_ec():
     dims = ["x", "y"]
     ex_ec = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
     ey_ec = xr.DataArray([[0, 2, 4], [1, 3, 5]], coords, dims)
-    dont_touch = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
-    return xr.Dataset({"ex_ec": ex_ec, "ey_ec": ey_ec, "dont_touch": dont_touch})
+    return xr.Dataset({"ex_ec": ex_ec, "ey_ec": ey_ec})
 
 
 def test_autorecenter_ec_to_nc(test_dataset_ec):
     pscpy.auto_recenter(test_dataset_ec, "nc", x="pad", y="pad")
     assert np.array_equal(test_dataset_ec.ex_nc, [[0, 1, 2], [1.5, 2.5, 3.5]])
     assert np.array_equal(test_dataset_ec.ey_nc, [[0, 1, 3], [1, 2, 4]])
-    assert np.array_equal(test_dataset_ec.dont_touch, [[0, 1, 2], [3, 4, 5]])
 
 
 def test_autorecenter_ec_to_cc(test_dataset_ec):
     pscpy.auto_recenter(test_dataset_ec, "cc", x="pad", y="pad")
     assert np.array_equal(test_dataset_ec.ex_cc, [[0.5, 1.5, 2], [3.5, 4.5, 5]])
     assert np.array_equal(test_dataset_ec.ey_cc, [[0.5, 2.5, 4.5], [1, 3, 5]])
-    assert np.array_equal(test_dataset_ec.dont_touch, [[0, 1, 2], [3, 4, 5]])
 
 
 @pytest.fixture
@@ -78,19 +75,30 @@ def test_dataset_fc():
     dims = ["x", "y"]
     hx_fc = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
     hy_fc = xr.DataArray([[0, 2, 4], [1, 3, 5]], coords, dims)
-    dont_touch = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
-    return xr.Dataset({"hx_fc": hx_fc, "hy_fc": hy_fc, "dont_touch": dont_touch})
+    return xr.Dataset({"hx_fc": hx_fc, "hy_fc": hy_fc})
 
 
 def test_autorecenter_fc_to_nc(test_dataset_fc):
     pscpy.auto_recenter(test_dataset_fc, "nc", x="pad", y="pad")
     assert np.array_equal(test_dataset_fc.hx_nc, [[0, 0.5, 1.5], [3, 3.5, 4.5]])
     assert np.array_equal(test_dataset_fc.hy_nc, [[0, 2, 4], [0.5, 2.5, 4.5]])
-    assert np.array_equal(test_dataset_fc.dont_touch, [[0, 1, 2], [3, 4, 5]])
 
 
 def test_autorecenter_fc_to_cc(test_dataset_fc):
     pscpy.auto_recenter(test_dataset_fc, "cc", x="pad", y="pad")
     assert np.array_equal(test_dataset_fc.hx_cc, [[1.5, 2.5, 3.5], [3, 4, 5]])
     assert np.array_equal(test_dataset_fc.hy_cc, [[1, 3, 4], [2, 4, 5]])
-    assert np.array_equal(test_dataset_fc.dont_touch, [[0, 1, 2], [3, 4, 5]])
+
+
+@pytest.fixture
+def test_dataset_dont_touch():
+    coords = [[0, 1, 2]]
+    dims = ["x"]
+    ex_ec = xr.DataArray([0, 1, 2], coords, dims)
+    dont_touch = xr.DataArray([0, 1, 2], coords, dims)
+    return xr.Dataset({"ex_ec": ex_ec, "dont_touch": dont_touch})
+
+
+def test_autorecenter_spurious_renames(test_dataset_dont_touch):
+    pscpy.auto_recenter(test_dataset_dont_touch, "cc", x="pad")
+    assert np.array_equal(test_dataset_dont_touch.dont_touch, [0, 1, 2])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import pscpy
+
+
+@pytest.fixture
+def test_dataarray():
+    return xr.DataArray([4, 5, 6, 5], coords={"x": [0, 1, 2, 3]})
+
+
+def test_recenter_periodic_left(test_dataarray):
+    recentered = pscpy.recenter(test_dataarray, "x", -1)
+    assert np.array_equal(recentered.coords, test_dataarray.coords)
+    assert np.array_equal(recentered, [4.5, 4.5, 5.5, 5.5])
+
+
+def test_recenter_periodic_right(test_dataarray):
+    recentered = pscpy.recenter(test_dataarray, "x", 1)
+    assert np.array_equal(recentered.coords, test_dataarray.coords)
+    assert np.array_equal(recentered, [4.5, 5.5, 5.5, 4.5])
+
+
+def test_recenter_pad_left(test_dataarray):
+    recentered = pscpy.recenter(test_dataarray, "x", -1, boundary="pad")
+    assert np.array_equal(recentered.coords, test_dataarray.coords)
+    assert np.array_equal(recentered, [4, 4.5, 5.5, 5.5])
+
+
+def test_recenter_pad_right(test_dataarray):
+    recentered = pscpy.recenter(test_dataarray, "x", 1, boundary="pad")
+    assert np.array_equal(recentered.coords, test_dataarray.coords)
+    assert np.array_equal(recentered, [4.5, 5.5, 5.5, 5])
+
+
+def test_recenter_zero_left(test_dataarray):
+    recentered = pscpy.recenter(test_dataarray, "x", -1, boundary="zero")
+    assert np.array_equal(recentered.coords, test_dataarray.coords)
+    assert np.array_equal(recentered, [2, 4.5, 5.5, 5.5])
+
+
+def test_recenter_zero_right(test_dataarray):
+    recentered = pscpy.recenter(test_dataarray, "x", 1, boundary="zero")
+    assert np.array_equal(recentered.coords, test_dataarray.coords)
+    assert np.array_equal(recentered, [4.5, 5.5, 5.5, 2.5])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -13,36 +13,36 @@ def test_dataarray():
 
 
 def test_recenter_periodic_left(test_dataarray):
-    recentered = pscpy.recenter(test_dataarray, "x", -1)
+    recentered = pscpy.get_recentered(test_dataarray, "x", -1)
     assert np.array_equal(recentered.coords, test_dataarray.coords)
     assert np.array_equal(recentered, [4.5, 4.5, 5.5, 5.5])
 
 
 def test_recenter_periodic_right(test_dataarray):
-    recentered = pscpy.recenter(test_dataarray, "x", 1)
+    recentered = pscpy.get_recentered(test_dataarray, "x", 1)
     assert np.array_equal(recentered.coords, test_dataarray.coords)
     assert np.array_equal(recentered, [4.5, 5.5, 5.5, 4.5])
 
 
 def test_recenter_pad_left(test_dataarray):
-    recentered = pscpy.recenter(test_dataarray, "x", -1, boundary="pad")
+    recentered = pscpy.get_recentered(test_dataarray, "x", -1, boundary="pad")
     assert np.array_equal(recentered.coords, test_dataarray.coords)
     assert np.array_equal(recentered, [4, 4.5, 5.5, 5.5])
 
 
 def test_recenter_pad_right(test_dataarray):
-    recentered = pscpy.recenter(test_dataarray, "x", 1, boundary="pad")
+    recentered = pscpy.get_recentered(test_dataarray, "x", 1, boundary="pad")
     assert np.array_equal(recentered.coords, test_dataarray.coords)
     assert np.array_equal(recentered, [4.5, 5.5, 5.5, 5])
 
 
 def test_recenter_zero_left(test_dataarray):
-    recentered = pscpy.recenter(test_dataarray, "x", -1, boundary="zero")
+    recentered = pscpy.get_recentered(test_dataarray, "x", -1, boundary="zero")
     assert np.array_equal(recentered.coords, test_dataarray.coords)
     assert np.array_equal(recentered, [2, 4.5, 5.5, 5.5])
 
 
 def test_recenter_zero_right(test_dataarray):
-    recentered = pscpy.recenter(test_dataarray, "x", 1, boundary="zero")
+    recentered = pscpy.get_recentered(test_dataarray, "x", 1, boundary="zero")
     assert np.array_equal(recentered.coords, test_dataarray.coords)
     assert np.array_equal(recentered, [4.5, 5.5, 5.5, 2.5])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -140,3 +140,16 @@ def test_dataset_dont_touch():
 def test_autorecenter_spurious_renames(test_dataset_dont_touch):
     pscpy.auto_recenter(test_dataset_dont_touch, "cc", x="pad")
     assert np.array_equal(test_dataset_dont_touch.dont_touch, [0, 1, 2])
+
+
+@pytest.fixture
+def test_dataset_nonstr_varname():
+    coords = [[0, 1, 2]]
+    dims = ["x"]
+    one = xr.DataArray([0, 1, 2], coords, dims)
+    return xr.Dataset({1: one})
+
+
+def test_nonstr_varname(test_dataset_nonstr_varname):
+    pscpy.auto_recenter(test_dataset_nonstr_varname, "nc", x="pad")
+    assert np.array_equal(test_dataset_nonstr_varname[1], [0, 1, 2])

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -91,6 +91,44 @@ def test_autorecenter_fc_to_cc(test_dataset_fc):
 
 
 @pytest.fixture
+def test_dataset_nc():
+    coords = [[0, 1], [0, 1, 2]]
+    dims = ["x", "y"]
+    var_nc = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
+    return xr.Dataset({"var_nc": var_nc})
+
+
+def test_autorecenter_nc_to_nc(test_dataset_nc):
+    # should do nothing
+    pscpy.auto_recenter(test_dataset_nc, "nc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_nc.var_nc, [[0, 1, 2], [3, 4, 5]])
+
+
+def test_autorecenter_nc_to_cc(test_dataset_nc):
+    pscpy.auto_recenter(test_dataset_nc, "cc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_nc.var_cc, [[2, 3, 3.5], [3.5, 4.5, 5]])
+
+
+@pytest.fixture
+def test_dataset_cc():
+    coords = [[0, 1], [0, 1, 2]]
+    dims = ["x", "y"]
+    var_cc = xr.DataArray([[0, 1, 2], [3, 4, 5]], coords, dims)
+    return xr.Dataset({"var_cc": var_cc})
+
+
+def test_autorecenter_cc_to_cc(test_dataset_cc):
+    # should do nothing
+    pscpy.auto_recenter(test_dataset_cc, "cc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_cc.var_cc, [[0, 1, 2], [3, 4, 5]])
+
+
+def test_autorecenter_cc_to_nc(test_dataset_cc):
+    pscpy.auto_recenter(test_dataset_cc, "nc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_cc.var_nc, [[0, 0.5, 1.5], [1.5, 2, 3]])
+
+
+@pytest.fixture
 def test_dataset_dont_touch():
     coords = [[0, 1, 2]]
     dims = ["x"]

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -61,3 +61,9 @@ def test_autorecenter_ec_to_nc(test_dataset_ec):
     pscpy.auto_recenter(test_dataset_ec, "nc", x="pad", y="pad")
     assert np.array_equal(test_dataset_ec.ex_nc, [[0, 1, 2], [1.5, 2.5, 3.5]])
     assert np.array_equal(test_dataset_ec.ey_nc, [[0, 1, 3], [1, 2, 4]])
+
+
+def test_autorecenter_ec_to_cc(test_dataset_ec):
+    pscpy.auto_recenter(test_dataset_ec, "cc", x="pad", y="pad")
+    assert np.array_equal(test_dataset_ec.ex_cc, [[0.5, 1.5, 2], [3.5, 4.5, 5]])
+    assert np.array_equal(test_dataset_ec.ey_cc, [[0.5, 2.5, 4.5], [1, 3, 5]])


### PR DESCRIPTION
Adds two new utility functions:
- `get_recentered`: creates a new `DataArray` by recentering a given array along a given dimension
- `auto_recenter`: automatically recenters variables in a given `Dataset` in-place according to given parameters

The intended workflow (for now) is for the user to call `decode_psc` and then, if desired, call `auto_recenter`. The `get_recentered` function might be useful when `auto_recenter` fails, and is thus also made available.

Both functions are also tested.

Optimization was not a consideration for this first implementation.