### PR TITLE
Always attempt to assign coordinates when decoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ ignore = [
   "PLR09",   # Too many <...>
   "PLR2004", # Magic value used in comparison
   "ISC001",  # Conflicts with formatter
+  "RET504",  # Assignment before return
 ]
 isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport

--- a/src/pscpy/psc.py
+++ b/src/pscpy/psc.py
@@ -27,6 +27,13 @@ class RunInfo:
         self.length = ds.attrs.get("length", length)
         self.corner = ds.attrs.get("corner", corner)
 
+        if self.length is None:
+            message = "Dataset is missing length. A value must be manually provided."
+            raise ValueError(message)
+        if self.corner is None:
+            message = "Dataset is missing corner. A value must be manually provided."
+            raise ValueError(message)
+
         self.x = self._get_coord(0)
         self.y = self._get_coord(1)
         self.z = self._get_coord(2)
@@ -121,13 +128,12 @@ def decode_psc(
         ds = ds.drop_vars([var_name])
     ds = ds.assign(data_vars)
 
-    if length is not None:
-        run_info = RunInfo(ds, length=length, corner=corner)
-        coords = {
-            "x": ("x", run_info.x),
-            "y": ("y", run_info.y),
-            "z": ("z", run_info.z),
-        }
-        ds = ds.assign_coords(coords)
+    run_info = RunInfo(ds, length=length, corner=corner)
+    coords = {
+        "x": ("x", run_info.x),
+        "y": ("y", run_info.y),
+        "z": ("z", run_info.z),
+    }
+    ds = ds.assign_coords(coords)
 
     return ds

--- a/tests/test_xarray_adios2.py
+++ b/tests/test_xarray_adios2.py
@@ -119,7 +119,7 @@ def test_nbytes():
 
 def test_missing_length():
     ds_raw = _open_dataset(pscpy.sample_dir / "pfd.000000400.bp")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r".*length.*"):
         pscpy.decode_psc(
             ds_raw,
             species_names=["e", "i"],
@@ -129,7 +129,7 @@ def test_missing_length():
 
 def test_missing_corner():
     ds_raw = _open_dataset(pscpy.sample_dir / "pfd.000000400.bp")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r".*corner.*"):
         pscpy.decode_psc(
             ds_raw,
             species_names=["e", "i"],

--- a/tests/test_xarray_adios2.py
+++ b/tests/test_xarray_adios2.py
@@ -117,6 +117,26 @@ def test_nbytes():
     assert ds_decoded.nbytes == ds_decoded.nbytes
 
 
+def test_missing_length():
+    ds_raw = _open_dataset(pscpy.sample_dir / "pfd.000000400.bp")
+    with pytest.raises(ValueError):
+        pscpy.decode_psc(
+            ds_raw,
+            species_names=["e", "i"],
+            corner=[0, -6.4, -25.6],
+        )
+
+
+def test_missing_corner():
+    ds_raw = _open_dataset(pscpy.sample_dir / "pfd.000000400.bp")
+    with pytest.raises(ValueError):
+        pscpy.decode_psc(
+            ds_raw,
+            species_names=["e", "i"],
+            length=[1, 12.8, 51.2],
+        )
+
+
 def test_computed():
     ds_raw = _open_dataset(pscpy.sample_dir / "pfd.000000400.bp")
     ds_decoded = _decode_dataset(ds_raw)


### PR DESCRIPTION
Previously, `length` had to be passed to `decode_psc` for coordinates to be assigned, even if the dataset had a length attribute. Now, `decode_psc` will always attempt to assign coordinates, and an error is thrown if no length (or corner) was given or present.

Also, ignore RET504, which came up after the above change. I don't like RET504 for 2 reasons:
1. naming quantities improves code readability
2. even if the variable isn't used now, it might be in the future, and the diff is nicer this way